### PR TITLE
Specify cookbook

### DIFF
--- a/definitions/mod_secure_proxy.rb
+++ b/definitions/mod_secure_proxy.rb
@@ -28,6 +28,7 @@ define :mod_secure_proxy, :enable => true do
   my_params = params
   
   web_app params[:name] do
+    cookbook "mod_security"
     template "mod_secure_proxy.conf.erb"
     server_name my_params[:server_name]
     server_aliases my_params[:server_aliases] 


### PR DESCRIPTION
Some may run into an issue where chef tries to find the template in the cookbook that requires this one. Specifically ran into this when using `include_recipe 'mod_security'`
