### PR TITLE
libexecdir in stead of libexec_dir...

### DIFF
--- a/recipes/install_base_apache.rb
+++ b/recipes/install_base_apache.rb
@@ -121,7 +121,7 @@ else
     package 'modsecurity-apache'
   end
 
-  libdir="#{node['apache']['libexec_dir']}"
+  libdir="#{node['apache']['libexecdir']}"
 
 end
 


### PR DESCRIPTION
This should fix #6 right now the wrong path is inserted in the modesecurity.load
