### PR TITLE
Adds love for Ubuntu packages too

### DIFF
--- a/recipes/install_base_apache.rb
+++ b/recipes/install_base_apache.rb
@@ -117,6 +117,9 @@ else
     package 'mod_security'
   when 'debian'
     package 'libapache-mod-security'
+  when 'ubuntu'
+    package 'libapache-modsecurity'
+    package 'modsecurity-crs'
   when 'arch'
     package 'modsecurity-apache'
   end


### PR DESCRIPTION
Ubuntu was added at the top, but not carried throughout the rest of the file when actually building the module.

The package name appears to change depending on the version of Ubuntu you're running, but this applies to 12.04 at the very least.
