### PR TITLE
Fix Ubuntu libraries

### DIFF
--- a/recipes/install_base_apache.rb
+++ b/recipes/install_base_apache.rb
@@ -186,4 +186,5 @@ end
 # Restore SE linux context audit log
 execute "Restore SE Linux context audit log" do
   command "chcon -t #{node[:mod_security][:audit_context]} '#{node[:mod_security][:audit_log]}'"
+  only_if { File.exist?('/selinux/status') && File.exist?("#{node[:mod_security][:audit_log]}") }
 end

--- a/recipes/install_base_apache.rb
+++ b/recipes/install_base_apache.rb
@@ -2,7 +2,7 @@
 case node[:platform_family]
 when 'rhel', 'fedora', 'suse'
   packages = %w[apr apr-util pcre-devel libxml2-devel curl-devel]
-when 'ubuntu', 'debian'
+when 'debian'
   packages = %w[libapr1 libaprutil1 libpcre3 libxml2 libcurl3]
 when 'arch'
   packages = %w[apr apr-util pcre libxml2 lib32-curl]
@@ -112,19 +112,19 @@ if node[:mod_security][:from_source]
 else
 
   # INSTALL FROM PACKAGE
-  case node[:platform_family]
-  when 'rhel', 'fedora', 'suse'
+  case node[:platform]
+  when 'redhat', 'centos', 'fedora', 'suse'
     package 'mod_security'
   when 'debian'
     package 'libapache-mod-security'
   when 'ubuntu'
-    package 'libapache-modsecurity'
+    package 'libapache2-modsecurity'
     package 'modsecurity-crs'
   when 'arch'
     package 'modsecurity-apache'
   end
 
-  libdir="#{node['apache']['libexecdir']}"
+  libdir="#{node['apache']['libexec_dir']}"
 
 end
 

--- a/test/integration/default/serverspec/mod_security_spec.rb
+++ b/test/integration/default/serverspec/mod_security_spec.rb
@@ -21,13 +21,22 @@ describe 'Apache2 with mod_security' do
     expect(file('/etc/apache2/mods-enabled/mod-security.conf')).to contain 'Include "/etc/apache2/mod_security/*.conf"'
   end
 
-  it 'apache2 should have a mod_security load file' do
-    expect(file('/etc/apache2/mods-enabled/mod-security.load')).to be_file
-    expect(file('/etc/apache2/mods-enabled/mod-security.load')).to contain 'LoadModule security2_module /usr/local/modsecurity/lib/mod_security2.so'
-  end
-
-  it 'mod_security module should exist' do
-    expect(file('/usr/local/modsecurity/lib/mod_security2.so')).to be_file
+  if (os[:family] == 'ubuntu') || (os[:family] == 'debian') then
+    it 'apache2 should have a mod_security load file' do
+      expect(file('/etc/apache2/mods-enabled/mod-security.load')).to be_file
+      expect(file('/etc/apache2/mods-enabled/mod-security.load')).to contain 'LoadModule security2_module /usr/lib/apache2/modules/mod_security2.so'
+    end
+    it 'mod_security module should exist' do
+      expect(file('/usr/lib/apache2/modules/mod_security2.so')).to be_file
+    end
+  else
+    it 'apache2 should have a mod_security load file' do
+      expect(file('/etc/apache2/mods-enabled/mod-security.load')).to be_file
+      expect(file('/etc/apache2/mods-enabled/mod-security.load')).to contain 'LoadModule security2_module /usr/local/modsecurity/lib/mod_security2.so'
+    end
+    it 'mod_security module should exist' do
+      expect(file('/usr/local/modsecurity/lib/mod_security2.so')).to be_file
+    end
   end
 
   it 'mod_security should be configured' do


### PR DESCRIPTION
Corrected using `platform` instead of `platform_family`. In order to fix #6 I've changed `libexec_dir` too, but seccubus has commited a nice fix in #35 .
