### PR TITLE
Include amazon linux mod_security package

### DIFF
--- a/recipes/install_base_apache.rb
+++ b/recipes/install_base_apache.rb
@@ -113,6 +113,8 @@ else
 
   # INSTALL FROM PACKAGE
   case node[:platform]
+  when 'amazon'
+    package 'mod24_security'
   when 'redhat', 'centos', 'fedora', 'suse'
     package 'mod_security'
   when 'debian'


### PR DESCRIPTION
Since the distinction for package names is done via platform and not platform family this part fails for Amazon Linux if we don't handle amazon linux separately.
I know it isn't on the list of supported OSes, but except for this feature everything else seems to work on Amazon Linux since it is part of the RHEL platform_family.
