### PR TITLE
Small fix to make cookbook not put shit in root of

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -45,7 +45,7 @@ default['mod_security']['crs']['version'] = '2.2.9'	# Default to the latest vers
 case node['platform_family']
 when 'windows'
   default['mod_security']['crs']['root_dir'] = (node['mod_security']['dir']).to_s
-  default['mod_security']['crs']['rules_root_dir'] = "#{node['mod_security']['crs']['root_dir']}/owasp_crs"
+  default['mod_security']['crs']['rules_root_dir'] = "#{node['mod_security']['dir']}/owasp_crs"
 else
   default['mod_security']['crs']['root_dir'] = "#{node['mod_security']['dir']}/crs"
   default['mod_security']['crs']['rules_root_dir'] = "#{node['mod_security']['crs']['root_dir']}/rules"

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ maintainer_email  'fbreedijk@schubergphilis.com'
 license           'Apache 2.0'
 description       'Installs and configures mod_security for Apache2 or IIS'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '0.2.8'
+version           '0.2.9'
 
 depends 'apache2'
 depends 'build-essential'


### PR DESCRIPTION
Small fix to make cookbook not put shit in root of C: drive and thus fails the chef run.
This problem was not an issue with chef-client 12.19.36.
It is an issue with 12.21.26 (maybe others in between as well).